### PR TITLE
Manage.py commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If you are pulling changes that affect the database, run:
 
 Custom `python manage.py` commands:
 - `createsuperuser` creates a superuser
+- `generate_inductees` generates a json file containing emails of inductees
 - `induct file.json` induct inductees (change their role to members)
   - JSON file format is [{"email": "example@domain.com"}]
 - `promote_officer file.json` promotes members to officers

--- a/myapp/api/management/commands/generate_inductees.py
+++ b/myapp/api/management/commands/generate_inductees.py
@@ -1,0 +1,24 @@
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import Group
+from myapp.api.models.users import CustomUser
+import json
+
+class Command(BaseCommand):
+   help = "Generate a json file of inductees"
+
+   def handle(self, *args, **kwargs):
+      inductee_group = Group.objects.get(name="inductee")
+      inductees = CustomUser.objects.filter(groups=inductee_group)
+
+
+      user_data = []
+
+      for user in inductees:
+         user_data.append({"email": user.email})
+      
+      output_file = 'inductees.json'
+
+      with open(output_file, 'w') as json_file:
+         json.dump(user_data, json_file, indent=4)
+      
+      print(f"Successfully exported {len(user_data)} inductee(s) to {output_file}")

--- a/myapp/api/management/commands/induct.py
+++ b/myapp/api/management/commands/induct.py
@@ -24,7 +24,10 @@ class Command(BaseCommand):
 
             try:
                 user = CustomUser.objects.get(email=email)
-                inductee = Inductee.objects.filter(user=user.user_id).first()
+                if Member.objects.filter(user=user.user_id).first() is not None:
+                    inductee = None
+                else:
+                    inductee = Inductee.objects.filter(user=user.user_id).first()
                 if inductee is None:
                     raise Inductee.DoesNotExist(
                         f"No matching Inductee found for user with email { email }"

--- a/myapp/api/management/commands/promote_officer.py
+++ b/myapp/api/management/commands/promote_officer.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
         if len(unchanged) != 0:
             print("\nUnchanged:")
             for message in unchanged:
-                print(unchanged)
+                print(message)
         if len(unsuccessful) != 0:
             print("\nUnsuccessful:")
             for email in unsuccessful:


### PR DESCRIPTION
- new command `generate_inductees` to generate a json file for inductees for use in `induct inducteees.json`
- update README to include new command
- fix bug where already inducted inductees can be re-inducted
- fix bug where unsuccessfully promoted users are printed multiple times in terminal