### PR TITLE
Default banner for different event type

### DIFF
--- a/frontend/src/Components/Events/EventCard.svelte
+++ b/frontend/src/Components/Events/EventCard.svelte
@@ -1,7 +1,8 @@
 <script>
     import { onMount } from 'svelte';
     import { getEvents } from "./eventstore";
-    
+    import { embedCode } from "./canvaEmbed.js";
+
     let events = [];
     let logo = "/static/Default_card_banner.png";
 
@@ -56,6 +57,10 @@
         {#if event.embed_code}
           <div class="embed-code">
             {@html event.embed_code}
+          </div>
+        {:else if Object.keys(embedCode).includes(event.event_type)}
+          <div class="embed-code">
+            {@html embedCode[event.event_type]}
           </div>
         {:else}
           <img class="default-image" src={logo} alt="{event.title}">

--- a/frontend/src/Components/Events/EventDetailContent.svelte
+++ b/frontend/src/Components/Events/EventDetailContent.svelte
@@ -2,6 +2,7 @@
     import { marked } from "marked";
     import * as purify from "dompurify";
     import EventConsole from "./EventConsole.svelte";
+    import { embedCode } from "./canvaEmbed.js";
 
     export let selectedEvent;
     $: start_time = new Date(selectedEvent?.start_time);
@@ -35,10 +36,13 @@
         {@html content}
     </div>
     {/if}
+
     <div class="canva-embed-code">
-    {#if selectedEvent.embed_code}
-        {@html selectedEvent.embed_code}
-    {/if}
+        {#if selectedEvent.embed_code}
+            {@html selectedEvent.embed_code}
+        {:else if Object.keys(embedCode).includes(selectedEvent.event_type)} 
+            {@html embedCode[selectedEvent.event_type]}
+        {/if}
     </div>
 
     <EventConsole event={selectedEvent}/>

--- a/frontend/src/Components/Events/canvaEmbed.js
+++ b/frontend/src/Components/Events/canvaEmbed.js
@@ -1,62 +1,31 @@
-const technical = `
-<div style="position: relative; width: 100%; height: 0; padding-top: 56.2500%; \
- padding-bottom: 0; box-shadow: 0 2px 8px 0 rgba(63,69,81,0.16); \
- margin-top: 1.6em; margin-bottom: 0.9em; overflow: hidden; \
- border-radius: 8px; will-change: transform;">
-  <iframe loading="lazy" style="position: absolute; width: 100%; height: 100%; \
- top: 0; left: 0; border: none; padding: 0;margin: 0;" \
- src="https://www.canva.com/design/DAF31CiRfDY/view?embed" \
- allowfullscreen="allowfullscreen" allow="fullscreen">
+const technical = `<div style="position: relative; width: 100%; height: 0; padding-top: 56.2500%; padding-bottom: 0; box-shadow: 0 2px 8px 0 rgba(63,69,81,0.16); margin-top: 1.6em; margin-bottom: 0.9em; overflow: hidden; border-radius: 8px; will-change: transform;">
+  <iframe loading="lazy" style="position: absolute; width: 100%; height: 100%; top: 0; left: 0; border: none; padding: 0; margin: 0;"
+    src="https://www.canva.com/design/DAF5a2Q6B7o/view?embed" allowfullscreen="allowfullscreen" allow="fullscreen">
   </iframe>
 </div>
-<a href="https://www.canva.com/design/DAF31CiRfDY/view?utm_content=DAF31CiRfDY&utm_campaign=designshare&utm_medium=embeds&utm_source=link" \
- target="_blank" rel="noopener">Technical_Event</a> by Lin Roger
-`;
+<a href="https://www.canva.com/design/DAF5a2Q6B7o/view?utm_content=DAF5a2Q6B7o&utm_campaign=designshare&utm_medium=embeds&utm_source=link" target="_blank" rel="noopener">Technical</a> by HKN Kappa Psi`;
 
-const professional = `
-<div style="position: relative; width: 100%; height: 0; padding-top: 56.2500%; \
- padding-bottom: 0; box-shadow: 0 2px 8px 0 rgba(63,69,81,0.16); \
- margin-top: 1.6em; margin-bottom: 0.9em; overflow: hidden; \
- border-radius: 8px; will-change: transform;">
-  <iframe loading="lazy" style="position: absolute; width: 100%; height: 100%; \
- top: 0; left: 0; border: none; padding: 0;margin: 0;" \
- src="https://www.canva.com/design/DAF31FbDHkU/view?embed" \
- allowfullscreen="allowfullscreen" allow="fullscreen">
+const professional = `<div style="position: relative; width: 100%; height: 0; padding-top: 56.2500%; padding-bottom: 0; box-shadow: 0 2px 8px 0 rgba(63,69,81,0.16); margin-top: 1.6em; margin-bottom: 0.9em; overflow: hidden; border-radius: 8px; will-change: transform;">
+  <iframe loading="lazy" style="position: absolute; width: 100%; height: 100%; top: 0; left: 0; border: none; padding: 0; margin: 0;"
+    src="https://www.canva.com/design/DAF5a-v4zys/view?embed" allowfullscreen="allowfullscreen" allow="fullscreen">
   </iframe>
 </div>
-<a href="https://www.canva.com/design/DAF31FbDHkU/view?utm_content=DAF31FbDHkU&utm_campaign=designshare&utm_medium=embeds&utm_source=link" \
- target="_blank" rel="noopener">Professional_Event</a> by Lin Roger
-`;
+<a href="https://www.canva.com/design/DAF5a-v4zys/view?utm_content=DAF5a-v4zys&utm_campaign=designshare&utm_medium=embeds&utm_source=link" target="_blank" rel="noopener">Professional Event</a> by HKN Kappa Psi`;
 
-const social = `
-<div style="position: relative; width: 100%; height: 0; padding-top: 56.2500%; \
- padding-bottom: 0; box-shadow: 0 2px 8px 0 rgba(63,69,81,0.16); \
- margin-top: 1.6em; margin-bottom: 0.9em; overflow: hidden; \
- border-radius: 8px; will-change: transform;">
-  <iframe loading="lazy" style="position: absolute; width: 100%; height: 100%; \
- top: 0; left: 0; border: none; padding: 0; margin: 0;" \
- src="https://www.canva.com/design/DAF31ATbzRs/view?embed" \
- allowfullscreen="allowfullscreen" allow="fullscreen">
+const social = `<div style="position: relative; width: 100%; height: 0; padding-top: 56.2500%; padding-bottom: 0; box-shadow: 0 2px 8px 0 rgba(63,69,81,0.16); margin-top: 1.6em; margin-bottom: 0.9em; overflow: hidden; border-radius: 8px; will-change: transform;">
+  <iframe loading="lazy" style="position: absolute; width: 100%; height: 100%; top: 0; left: 0; border: none; padding: 0; margin: 0;"
+    src="https://www.canva.com/design/DAFSjPBOyW0/view?embed" allowfullscreen="allowfullscreen" allow="fullscreen">
   </iframe>
 </div>
-<a href="https://www.canva.com/design/DAF31ATbzRs/view?utm_content=DAF31ATbzRs&utm_campaign=designshare&utm_medium=embeds&utm_source=link" \
- target="_blank" rel="noopener">Social_Event</a> by Lin Roger
-`;
+<a href="https://www.canva.com/design/DAFSjPBOyW0/view?utm_content=DAFSjPBOyW0&utm_campaign=designshare&utm_medium=embeds&utm_source=link" target="_blank" rel="noopener">Events</a> by HKN Kappa Psi`;
 
-const mentorship = `
-<div style="position: relative; width: 100%; height: 0; padding-top: 56.2500%; \
- padding-bottom: 0; box-shadow: 0 2px 8px 0 rgba(63,69,81,0.16); \
- margin-top: 1.6em; margin-bottom: 0.9em; overflow: hidden; \
- border-radius: 8px; will-change: transform;">
-  <iframe loading="lazy" style="position: absolute; width: 100%; height: 100%; \
- top: 0; left: 0; border: none; padding: 0; margin: 0;" \
- src="https://www.canva.com/design/DAF31MMZfHw/view?embed" \
- allowfullscreen="allowfullscreen" allow="fullscreen">
+
+const mentorship = `<div style="position: relative; width: 100%; height: 0; padding-top: 56.2500%; padding-bottom: 0; box-shadow: 0 2px 8px 0 rgba(63,69,81,0.16); margin-top: 1.6em; margin-bottom: 0.9em; overflow: hidden; border-radius: 8px; will-change: transform;">
+  <iframe loading="lazy" style="position: absolute; width: 100%; height: 100%; top: 0; left: 0; border: none; padding: 0; margin: 0;"
+    src="https://www.canva.com/design/DAF5a6OveXs/view?embed" allowfullscreen="allowfullscreen" allow="fullscreen">
   </iframe>
 </div>
-<a href="https://www.canva.com/design/DAF31MMZfHw/view?utm_content=DAF31MMZfHw&utm_campaign=designshare&utm_medium=embeds&utm_source=link" \
- target="_blank" rel="noopener">Mentorship_Event</a> by Lin Roger
-`;
+<a href="https://www.canva.com/design/DAF5a6OveXs/view?utm_content=DAF5a6OveXs&utm_campaign=designshare&utm_medium=embeds&utm_source=link" target="_blank" rel="noopener">Mentorship</a> by HKN Kappa Psi`;
 
 export const embedCode = {
   "Technical" : technical,

--- a/frontend/src/Components/Events/canvaEmbed.js
+++ b/frontend/src/Components/Events/canvaEmbed.js
@@ -1,0 +1,66 @@
+const technical = `
+<div style="position: relative; width: 100%; height: 0; padding-top: 56.2500%; \
+ padding-bottom: 0; box-shadow: 0 2px 8px 0 rgba(63,69,81,0.16); \
+ margin-top: 1.6em; margin-bottom: 0.9em; overflow: hidden; \
+ border-radius: 8px; will-change: transform;">
+  <iframe loading="lazy" style="position: absolute; width: 100%; height: 100%; \
+ top: 0; left: 0; border: none; padding: 0;margin: 0;" \
+ src="https://www.canva.com/design/DAF31CiRfDY/view?embed" \
+ allowfullscreen="allowfullscreen" allow="fullscreen">
+  </iframe>
+</div>
+<a href="https://www.canva.com/design/DAF31CiRfDY/view?utm_content=DAF31CiRfDY&utm_campaign=designshare&utm_medium=embeds&utm_source=link" \
+ target="_blank" rel="noopener">Technical_Event</a> by Lin Roger
+`;
+
+const professional = `
+<div style="position: relative; width: 100%; height: 0; padding-top: 56.2500%; \
+ padding-bottom: 0; box-shadow: 0 2px 8px 0 rgba(63,69,81,0.16); \
+ margin-top: 1.6em; margin-bottom: 0.9em; overflow: hidden; \
+ border-radius: 8px; will-change: transform;">
+  <iframe loading="lazy" style="position: absolute; width: 100%; height: 100%; \
+ top: 0; left: 0; border: none; padding: 0;margin: 0;" \
+ src="https://www.canva.com/design/DAF31FbDHkU/view?embed" \
+ allowfullscreen="allowfullscreen" allow="fullscreen">
+  </iframe>
+</div>
+<a href="https://www.canva.com/design/DAF31FbDHkU/view?utm_content=DAF31FbDHkU&utm_campaign=designshare&utm_medium=embeds&utm_source=link" \
+ target="_blank" rel="noopener">Professional_Event</a> by Lin Roger
+`;
+
+const social = `
+<div style="position: relative; width: 100%; height: 0; padding-top: 56.2500%; \
+ padding-bottom: 0; box-shadow: 0 2px 8px 0 rgba(63,69,81,0.16); \
+ margin-top: 1.6em; margin-bottom: 0.9em; overflow: hidden; \
+ border-radius: 8px; will-change: transform;">
+  <iframe loading="lazy" style="position: absolute; width: 100%; height: 100%; \
+ top: 0; left: 0; border: none; padding: 0; margin: 0;" \
+ src="https://www.canva.com/design/DAF31ATbzRs/view?embed" \
+ allowfullscreen="allowfullscreen" allow="fullscreen">
+  </iframe>
+</div>
+<a href="https://www.canva.com/design/DAF31ATbzRs/view?utm_content=DAF31ATbzRs&utm_campaign=designshare&utm_medium=embeds&utm_source=link" \
+ target="_blank" rel="noopener">Social_Event</a> by Lin Roger
+`;
+
+const mentorship = `
+<div style="position: relative; width: 100%; height: 0; padding-top: 56.2500%; \
+ padding-bottom: 0; box-shadow: 0 2px 8px 0 rgba(63,69,81,0.16); \
+ margin-top: 1.6em; margin-bottom: 0.9em; overflow: hidden; \
+ border-radius: 8px; will-change: transform;">
+  <iframe loading="lazy" style="position: absolute; width: 100%; height: 100%; \
+ top: 0; left: 0; border: none; padding: 0; margin: 0;" \
+ src="https://www.canva.com/design/DAF31MMZfHw/view?embed" \
+ allowfullscreen="allowfullscreen" allow="fullscreen">
+  </iframe>
+</div>
+<a href="https://www.canva.com/design/DAF31MMZfHw/view?utm_content=DAF31MMZfHw&utm_campaign=designshare&utm_medium=embeds&utm_source=link" \
+ target="_blank" rel="noopener">Mentorship_Event</a> by Lin Roger
+`;
+
+export const embedCode = {
+  "Technical" : technical,
+  "Professional" : professional,
+  "Mentorship" : mentorship,
+  "Social" : social,
+}


### PR DESCRIPTION
Created canvaEmbed.js that stores each events(Professional, technical, mentorship, social) canva embed code.
export to eventcard and eventdetailcontent to implement default banner when no specific embed code updated. 