### PR TITLE
Fix redirecting issue

### DIFF
--- a/myapp/api/views/user_views.py
+++ b/myapp/api/views/user_views.py
@@ -387,7 +387,7 @@ def inductee_form(request, token):
                 return redirect(reverse("inductee_form_complete"))
 
             form = InducteeForm()
-            return render(request, "registration/inductee_form.html", {"form": form})
+            return render(request, "registration/inductee_form.html", {"form": form, "class_token": token})
         
         if request.method == "POST":
             form = InducteeForm(request.POST)

--- a/myapp/templates/registration/inductee_form.html
+++ b/myapp/templates/registration/inductee_form.html
@@ -63,7 +63,7 @@
             </script>
          </form>
       {% else %}
-         <p>You are not logged in, please <a href="{% url 'login' %}?next=/inductee_form/">login</a> or <a href="{% url 'register' %}?next=/inductee_form/">register</a> an account.</p>
+         <p>You are not logged in, please <a href="{% url 'login' %}?next=/inductee_form/{{ class_token }}/">login</a> or <a href="{% url 'register' %}?next=/inductee_form/{{ class_token }}/">register</a> an account.</p>
       {% endif %}
    </div>
 </body>


### PR DESCRIPTION
Log in or register should automatically redirect back to inductee form if accessed from the form. However, the redirect link was not updated when we added the induction class token to the form.