### PR TITLE
fixed csv file bug

### DIFF
--- a/frontend/src/Pages/Inductees.svelte
+++ b/frontend/src/Pages/Inductees.svelte
@@ -134,7 +134,12 @@
 
                 // Get the text data of each cell
                 // of a row and push it to csvrow
-                csvrow.push(cols[j].innerHTML);
+                if (j == 0 && i != 0) {
+                    var element = cols[j].querySelector('a');
+                    csvrow.push(element.innerHTML);
+                } else {
+                    csvrow.push(cols[j].innerHTML);
+                }
             }
 
             // Combine each column value with comma
@@ -206,7 +211,7 @@
                 </form>
             </div>
             <div>
-                <button type="button" on:click={() => download_table()}>
+                <button id="downloadButton" type="button" on:click={() => download_table()}>
                     Download as CSV
                 </button>
             </div>
@@ -349,6 +354,11 @@
         padding:0px;
         margin:0px;
     }
+
+    #downloadButton:hover {
+        cursor: pointer;
+    }
+
     #key {
         position:fixed;
         top:60px;

--- a/frontend/src/Pages/Outreach.svelte
+++ b/frontend/src/Pages/Outreach.svelte
@@ -110,7 +110,12 @@
 
                 // Get the text data of each cell
                 // of a row and push it to csvrow
-                csvrow.push(cols[j].innerHTML);
+                if (j == 0 && i != 0) {
+                    var element = cols[j].querySelector('a');
+                    csvrow.push(element.innerHTML);
+                } else {
+                    csvrow.push(cols[j].innerHTML);
+                }
             }
 
             // Combine each column value with comma
@@ -172,7 +177,7 @@
                 </div>
                 
                 <div>
-                    <button type="button" on:click={() => download_table()}>
+                    <button id="downloadButton" type="button" on:click={() => download_table()}>
                         Download as CSV
                     </button>
                 </div>
@@ -281,4 +286,9 @@
         padding: 10px;
         overflow: wrap;
     }
+
+    #downloadButton:hover {
+        cursor: pointer;
+    }
+
 </style>


### PR DESCRIPTION
Fixed download csv bug.

After adding link to profile page for each user in the table, the tableToCSV was parsing the table incorrectly and including the entire <a> element instead of just the first name.

In this bug fix, I changed tableToCSV to take the innerHTML of this <a> element, specifically when parsing the first element of a row, and only if it is not the first row (should just be "First Name").