### PR TITLE
Resolve profile page events display

### DIFF
--- a/frontend/src/Components/Events/EventCard.svelte
+++ b/frontend/src/Components/Events/EventCard.svelte
@@ -82,8 +82,8 @@ on:click={() => dispatchEvent(event)}>
             }"
         on:click={(e) => toggleRSVP(event, e)}
     >
-        {RSVP.find((record) => record.event == event.pk) ? "RSVP'd ★" : "RSVP"}
+      {RSVP.find((record) => record.event == event.pk) ? "RSVP'd ★" : "RSVP"}
     </button>
-</div>
+  </div>
   {/if}
 </div>

--- a/frontend/src/Components/Events/EventsCard.svelte
+++ b/frontend/src/Components/Events/EventsCard.svelte
@@ -39,7 +39,8 @@
 
     //check if the event is already RSVP'd
     if (RSVP.find((record) => record.event == event.pk)) {
-      deleteAction(RSVP.find((record) => record.event == event.pk).pk);      } else {
+      deleteAction(RSVP.find((record) => record.event == event.pk).pk);
+    } else {
       await requestAction(event, "RSVP",userData);
       }
     await getUserData();
@@ -48,7 +49,10 @@
 
   onMount(async () => {
     // Fetch events from the server
-      await getUserData();
+      await new Promise((resolve) => {
+        getUserData();
+        resolve();
+      });
       const curr = new Date().toISOString();
   });
 
@@ -74,9 +78,9 @@
 
       <div class="flex flex-col md:flex-row overflow-x-auto {subtitle? "mt-3":"mt-6"}">
 
-        {#each events as event}
-          <EventCard {event} {toggleRSVP} {RSVP} {RSVPEnabled} on:sendToHome={handleEventClick}/>
-        {/each}
+      {#each events as event}
+        <EventCard event={event} toggleRSVP={toggleRSVP} RSVP={RSVP} RSVPEnabled={RSVPEnabled} on:sendToHome={handleEventClick}/>
+      {/each}
       </div>
 
       {/if}

--- a/frontend/src/Pages/Profile.svelte
+++ b/frontend/src/Pages/Profile.svelte
@@ -210,16 +210,20 @@
          await getUserData();
          getUserGroups();
       } else {
-         self = true;
-         unsubscribe = userStore.subscribe(value => {
-            if (value) {
-               user = value;
-               getUserGroups();
-            }
-         })
+         await new Promise((resolve) => {
+            unsubscribe = userStore.subscribe((value) => {
+               if (value) {
+                  self = true;
+                  user = value;
+                  getUserGroups();
+                  resolve();
+               }
+            });
+         });
       }
       await getRSVPs();
       await getCheckOffs();
+
       const handleKeydown = (event) => {
       if (event.key === "Escape") {
          closePopup();
@@ -342,7 +346,7 @@
       <!-- Events -->
       <div class="space-y-6 w-full lg:w-3/4">
          <!-- Previously Attended Events -->
-         <EventsCard title="RSVP'd Events" subtitle="See you there!" events={rsvpEvents} handleEventClick={handleEventClick} />
+         <EventsCard title="RSVP'd Events" subtitle="See you there!" events={rsvpEvents} RSVPEnabled={true} handleEventClick={handleEventClick} />
          <!-- RSVP'd Events -->
          <EventsCard title="Previously Attended Events" subtitle="Thank you for coming!" events={attendedEvents} RSVPEnabled={false} handleEventClick={handleEventClick}/>
       </div>


### PR DESCRIPTION
Turn fetching events into promises to wait for.
For users with fewer eventactionrecords, API fetches are too quick and can cause issues.